### PR TITLE
feat!: rename icon path fields to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ await msiCreator.compile();
 * `description` (string) - The app's description.
 * `version` (string) - The app's version.
 * `name` (string) - The app's name.
-* `appIconPath` 🆕 (string, optional) - A path to the Apps icon used for the stub executable.
+* `icon` 🆕 (string, optional) - A path to the Apps icon used for the stub executable.
    If not provided a lower quality version will be extracted form the `exe`
 * `manufacturer` (string) - Name of the manufacturer.
 

--- a/e2e/src/utils/msi-packager.ts
+++ b/e2e/src/utils/msi-packager.ts
@@ -10,7 +10,7 @@ export const defaultMsiOptions: MSICreatorOptions = {
   exe: 'HelloWix.exe',
   manufacturer: 'Wix Technologies',
   name: 'HelloWix',
-  appIconPath: path.join(HARNESS_APP_DIR, '../HelloWix.ico'),
+  icon: path.join(HARNESS_APP_DIR, '../HelloWix.ico'),
   outputDirectory: OUT_DIR,
   description: 'A hello wix package',
   ui: {

--- a/harness/harness.js
+++ b/harness/harness.js
@@ -17,7 +17,7 @@ async function harness() {
     exe: 'HelloWix.exe',
     manufacturer: 'Wix Technologies',
     name: 'HelloWix',
-    appIconPath: path.join(APP_DIR, '../HelloWix.ico'),
+    icon: path.join(APP_DIR, '../HelloWix.ico'),
     outputDirectory: OUT_DIR,
     description: 'A hello wix package',
     toastActivatorClsid: '808ba5f6-12a4-4175-8cfe-9c10a6b1bab6',

--- a/src/creator.ts
+++ b/src/creator.ts
@@ -37,7 +37,7 @@ export interface MSICreatorOptions {
   toastActivatorClsid?: string;
   description: string;
   exe: string;
-  appIconPath?: string;
+  icon?: string;
   extensions?: Array<string>;
   lightSwitches?: Array<string>;
   cultures?: string;
@@ -115,7 +115,7 @@ export class MSICreator {
   public toastActivatorClsid?: string;
   public description: string;
   public exe: string;
-  public iconPath?: string;
+  public icon?: string;
   public extensions: Array<string>;
   public lightSwitches: Array<string>;
   public cultures?: string;
@@ -159,7 +159,7 @@ export class MSICreator {
     this.certificatePassword = options.certificatePassword;
     this.description = options.description;
     this.exe = options.exe.replace(/\.exe$/, '');
-    this.iconPath = options.appIconPath;
+    this.icon = options.icon;
     this.extensions = options.extensions || [];
     this.lightSwitches = options.lightSwitches || [];
     this.cultures = options.cultures;
@@ -676,7 +676,7 @@ export class MSICreator {
       this.manufacturer,
       this.description,
       this.windowsCompliantVersion,
-      this.iconPath);
+      this.icon);
 
     const installInfoFile = createInstallInfoFile(this.manufacturer,
                                                   this.shortName,


### PR DESCRIPTION
Co-authored-by: Keeley Hammond <vertedinde@electronjs.org>

This change aims to bring icon path config names in line with other `electron-forge` `makers` to improve clarity for users.

note that this would be a breaking change as this is an option name, and would need to be communicated in the forge release notes.

related issue: github.com/electron-userland/electron-forge/issues/1994
related guide doc for forge: https://github.com/electron-forge/electron-forge-docs/pull/74/files