### PR TITLE
add options: codepage

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -41,6 +41,7 @@ export interface MSICreatorOptions {
   extensions?: Array<string>;
   lightSwitches?: Array<string>;
   cultures?: string;
+  codepage?:string;
   language?: number;
   manufacturer: string;
   name: string;
@@ -119,6 +120,7 @@ export class MSICreator {
   public extensions: Array<string>;
   public lightSwitches: Array<string>;
   public cultures?: string;
+  public codepage: string;
   public language: number;
   public manufacturer: string;
   public name: string;
@@ -163,6 +165,7 @@ export class MSICreator {
     this.extensions = options.extensions || [];
     this.lightSwitches = options.lightSwitches || [];
     this.cultures = options.cultures;
+    this.codepage = options.codepage || '1252';
     this.language = options.language || 1033;
     this.manufacturer = options.manufacturer;
     this.name = options.name;
@@ -303,6 +306,7 @@ export class MSICreator {
       '{{ApplicationShortcutGuid}}': uuid(),
       '{{ApplicationShortName}}': this.shortName,
       '{{AppUserModelId}}': this.appUserModelId,
+      '{{Codepage}}': this.codepage,
       '{{Language}}': this.language.toString(10),
       '{{Manufacturer}}': this.manufacturer,
       '{{ShortcutFolderName}}': this.shortcutFolderName,

--- a/static/wix.xml
+++ b/static/wix.xml
@@ -6,6 +6,7 @@
            Name = "{{ApplicationName}} (Machine - MSI)"
            Version="{{Version}}"
            Manufacturer="{{Manufacturer}}"
+           Codepage="{{Codepage}}"
            Language="{{Language}}">
     <!-- Only run this installer on Windows 7 or up (or if it"s already installed, I guess) -->
     <!-- <Condition Message="This application is only supported on Windows 7 or higher.">


### PR DESCRIPTION
bug:

If the name, description, and other options contain Chinese or Japanese characters, an error message is displayed:

error LGHT0311 : A string was provided with characters that are not available in the specified database code page '1252'. Either change these characters to ones that exist in the database's code page, or update the database's code page by modifying one of the following attributes: Product/@Codepage, Module/@Codepage, Patch/@Codepage, PatchCreation/@Codepage, or WixLocalization/@Codepage.

fix:

```
const msiCreator = new MSICreator({
  appDirectory: '/path/to/built/app',
  description: '中文产品描述',
  exe: 'kittens',
  name: 'Kittens',
  manufacturer: '深圳云艺帆教育科技有限公司',
  version: '1.1.2',
  outputDirectory: '/path/to/output/folder',
  lang: 2052, 
  // use codepage to fix bug
  codepage: '936'
});
```


